### PR TITLE
update alert default threshold for deprecated deployment

### DIFF
--- a/jobs/boshupdate_alerts/spec
+++ b/jobs/boshupdate_alerts/spec
@@ -9,5 +9,5 @@ templates:
 properties:
   boshupdate_alerts.deploymentdeprecated.threshold:
     description: "Maximum number of days since deployment is deprecated"
-    default: 40
+    default: 77
 


### PR DESCRIPTION
Need to update alert default threshold for deprecated deployment.
* threshold 40 to 77 days